### PR TITLE
change git url to https because of permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ So if you want to be super prepared and if you've managed to install Git and Vag
 please clone this repository:
 
 ```
-git clone git@github.com:wallrj/docker-tutorial.git
+git clone https://github.com/wallrj/docker-tutorial.git
 ```
 
 Then change to the `docker-tutorial` directory


### PR DESCRIPTION
Hi Richard, with the git@github.com URL, people don't have read access to the repository, this is something we came across at Carl's workshop last time. So I changed it to https://github.com
- Just installed everything and got the docker hello world running in the vagrant. Magic!
